### PR TITLE
Method Invocations - Type Checker/Interpreter Update

### DIFF
--- a/src/ast/expressions/Invocation.java
+++ b/src/ast/expressions/Invocation.java
@@ -13,6 +13,8 @@ public class Invocation extends Expression {
     private Name name;
     private Vector<Expression> args;
 
+    private String invokeSignature;
+
     public Invocation(Token t, Name fn, Vector<Expression> p) { this(t,null, fn, p); }
 
     public Invocation(Token t, Expression e, Name fn, Vector<Expression> p) {
@@ -33,6 +35,10 @@ public class Invocation extends Expression {
 
     public boolean isInvocation() { return true; }
     public Invocation asInvocation() { return this; }
+
+    public void setTarget(Expression e) { if(this.target == null) { this.target = e;} }
+    public void setInvokeSignature(String inSig) { this.invokeSignature = inSig; }
+    public String invokeSignature() { return this.invokeSignature; }
 
     @Override
     public String toString() { return name.toString(); }

--- a/src/interpreter/Interpreter.java
+++ b/src/interpreter/Interpreter.java
@@ -625,13 +625,11 @@ public class Interpreter extends Visitor {
                 searchMethod = methodName + "_" + startClass.toString();
             }
             methodName = searchMethod;
-//            if(cd.superClass() != null && in.type.) {
-//                methodName += "_" + cd.toString();
-//            }
+
             MethodDecl md = cd.symbolTable.findName(methodName).decl().asMethodDecl();
             currentScope = md.symbolTable;
 
-            for(String s : obj.keySet()) { stack.addValue(s,obj.get(s)); }
+            // for(String s : obj.keySet()) { stack.addValue(s,obj.get(s)); }
 
             for(int i = 0; i < in.arguments().size(); i++) {
                 ParamDecl currParam = md.params().get(i);
@@ -727,7 +725,7 @@ public class Interpreter extends Visitor {
 
         currValue = instance;
 
-        cd.constructor().visit(this);
+        if(cd.constructor() != null) { cd.constructor().visit(this); }
     }
 
     /*

--- a/src/modifier_checker/ModifierChecker.java
+++ b/src/modifier_checker/ModifierChecker.java
@@ -264,7 +264,7 @@ public class ModifierChecker extends Visitor {
         String funcSignature = in.invokeSignature();
 
         // Function Invocation Case
-        if(in.target() == null) {
+        if(in.target() == null && !in.targetType.isClassType()) {
             FuncDecl fd = currentScope.findName(funcSignature).decl().asTopLevelDecl().asFuncDecl();
 
             if(currentContext == fd && fd.funcSignature().equals(funcSignature))  {
@@ -281,7 +281,7 @@ public class ModifierChecker extends Visitor {
         }
         // Method Invocation Case
         else {
-            ClassDecl cd = currentScope.findName(in.target().type.typeName()).decl().asTopLevelDecl().asClassDecl();
+            ClassDecl cd = currentScope.findName(in.targetType.typeName()).decl().asTopLevelDecl().asClassDecl();
             while(!cd.symbolTable.hasName(funcSignature)) {
                 cd = currentScope.findName(cd.superClass().toString()).decl().asTopLevelDecl().asClassDecl();
             }
@@ -299,7 +299,7 @@ public class ModifierChecker extends Visitor {
                             .error());
                 }
             }
-            // ERROR CHECK #3: An object can only a method that is declared public
+            // ERROR CHECK #3: An object can only access a method that is declared public
             if(!md.mods.isPublic()) {
                     errors.add(new ErrorBuilder(generateModError,interpretMode)
                             .addLocation(in)

--- a/src/type_checker/TypeChecker.java
+++ b/src/type_checker/TypeChecker.java
@@ -592,7 +592,6 @@ public class TypeChecker extends Visitor {
             }   while(currentScope.hasName(baseClass));
 
             cd.setClassHierarchy(new ClassType(new Name(inheritedClasses)));
-            System.out.println(inheritedClasses);
         } else { cd.setClassHierarchy(new ClassType(new Name(cd.toString()))); }
 
         currentScope = cd.symbolTable;

--- a/src/type_checker/TypeChecker.java
+++ b/src/type_checker/TypeChecker.java
@@ -1149,12 +1149,13 @@ public class TypeChecker extends Visitor {
     _____________________________________________________________________
     */
     public void visitNameExpr(NameExpr ne) {
-        NameNode decl = currentScope.findName(ne.toString());
+        NameNode name = currentScope.findName(ne.toString());
 
-        if(decl.decl().isStatement()) { ne.type = decl.decl().asStatement().asLocalDecl().type(); }
-        else if(decl.decl().isParamDecl()) { ne.type = decl.decl().asParamDecl().type(); }
-        else if(decl.decl().isTopLevelDecl()) {
-            TopLevelDecl tDecl = decl.decl().asTopLevelDecl();
+        if(name.decl().isStatement()) { ne.type = name.decl().asStatement().asLocalDecl().type(); }
+        else if(name.decl().isParamDecl()) { ne.type = name.decl().asParamDecl().type(); }
+        else if(name.decl().isFieldDecl()) { ne.type = name.decl().asFieldDecl().type(); }
+        else if(name.decl().isTopLevelDecl()) {
+            TopLevelDecl tDecl = name.decl().asTopLevelDecl();
 
             if(tDecl.isGlobalDecl()) { ne.type = tDecl.asGlobalDecl().type();}
             else if(tDecl.isEnumDecl()) { ne.type = tDecl.asEnumDecl().constantType(); }


### PR DESCRIPTION
# Overview
This PR fixes #10 and now method invocations can properly be called inside of method declarations. 

# Description
The reason why method invocations were not working was because I failed to account for the context in which the method needs to be called from. In this case, I didn't know what object was trying to call a method inside the body of a method declaration, so it was resulting in an exception. This has now been fixed by the addition of the `this` pointer.

In the future, we will add a keyword for `this` (or we will use a different keyword) to give the user the ability to perform self-references inside of classes. In the type checker, there is now a check to see if we are inside of a class when we are visiting a method invocation. If this is true, then that means we will analyze a call to a method invocation instead of a function invocation and if the target wasn't specified to us, then we will implicitly add the target to be `this`.

When we then go to interpret the invocation, we will add a reference to the object via a `this` pointer, so any time we are inside a method, we have access to the correct object that called it. 
