### PR TITLE
Redesign - For Statements

### DIFF
--- a/src/ast/AST.java
+++ b/src/ast/AST.java
@@ -128,6 +128,9 @@ public abstract class AST {
     public boolean isType() { return false; }
     public Type asType() { throw new RuntimeException("Expression can not be casted into a Type.\n"); }
 
+    public boolean isVar() { return false; }
+    public Var asVar() { throw new RuntimeException("Expression can not be casted into a Var.\n"); }
+
     public Vector asVector() { throw new RuntimeException("Expression can not be casted into a Vector.\n"); }
 
     public static boolean notNull(AST n) { return n != null;}

--- a/src/ast/expressions/Literal.java
+++ b/src/ast/expressions/Literal.java
@@ -21,5 +21,16 @@ public class Literal extends Expression {
     public Literal asLiteral() { return this; }
 
     @Override
+    public String toString() {
+        switch(kind) {
+            case INT:
+                if(this.getText().startsWith("~")) {return "-" + this.getText().substring(1); }
+                else { return this.getText(); }
+            default:
+                return this.getText();
+        }
+    }
+
+    @Override
     public void visit(Visitor v) { v.visitLiteral(this); }
 }

--- a/src/ast/operators/LoopOp.java
+++ b/src/ast/operators/LoopOp.java
@@ -1,0 +1,27 @@
+package ast.operators;
+
+import token.Token;
+import utilities.Visitor;
+
+public class LoopOp extends Operator {
+
+    public static enum LoopType { INCL, EXCL, EXCL_L, EXCL_R }
+    public static String[] names = { "..", "<..<", "<..", "..<" };
+
+    private LoopType op;
+
+    public LoopOp(Token t, LoopType lt) {
+        super(t);
+        this.op = lt;
+    }
+
+    public LoopType loopType() { return op; }
+    public boolean isLoopOp() { return true; }
+    public LoopOp asLoopOp() { return this; }
+
+    @Override
+    public String toString() { return names[op.ordinal()]; }
+
+    @Override
+    public void visit(Visitor v) { v.visitLoopOp(this); }
+}

--- a/src/ast/operators/Operator.java
+++ b/src/ast/operators/Operator.java
@@ -10,12 +10,15 @@ public abstract class Operator extends AST {
     public boolean isOperator() { return true; }
     public Operator asOperator() { return this; }
 
+    public boolean isAssignOp() { return false; }
+    public AssignOp asAssignOp() { throw new RuntimeException("Expression can not be casted into an AssignOp.\n"); }
+
     public boolean isBinaryOp() { return false; }
     public BinaryOp asBinaryOp() { throw new RuntimeException("Expression can not be casted into a BinaryOp.\n"); }
 
+    public boolean isLoopOp() { return false; }
+    public LoopOp asLoopOp() { throw new RuntimeException("Expression can not be casted into a LoopOp.\n"); }
+
     public boolean isUnaryOp() { return false; }
     public UnaryOp asUnaryOp() { throw new RuntimeException("Expression can not be casted into a UnaryOp.\n"); }
-
-    public boolean isAssignOp() { return false; }
-    public AssignOp asAssignOp() { throw new RuntimeException("Expression can not be casted into an AssignOp.\n"); }
 }

--- a/src/ast/statements/ForStmt.java
+++ b/src/ast/statements/ForStmt.java
@@ -11,15 +11,15 @@ public class ForStmt extends Statement {
 
     public SymbolTable symbolTable;
 
-    private Var loopControlVar;
+    private LocalDecl loopControlVar;
     private Expression LHS;
     private Expression RHS;
     private LoopOp lOp;
     private BlockStmt body;
 
-    public ForStmt(Token t, Var v, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
+    public ForStmt(Token t, LocalDecl ld, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
         super(t);
-        this.loopControlVar = v;
+        this.loopControlVar = ld;
         this.LHS = LHS;
         this.RHS = RHS;
         this.lOp = lOp;
@@ -33,7 +33,7 @@ public class ForStmt extends Statement {
         setParent();
     }
 
-    public Var loopVar() { return this.loopControlVar; }
+    public LocalDecl loopVar() { return this.loopControlVar; }
     public Expression condLHS() { return this.LHS; }
     public Expression condRHS() { return this.RHS; }
     public LoopOp loopOp() { return this.lOp; }

--- a/src/ast/statements/ForStmt.java
+++ b/src/ast/statements/ForStmt.java
@@ -2,6 +2,7 @@ package ast.statements;
 
 import ast.*;
 import ast.expressions.*;
+import ast.operators.LoopOp;
 import token.*;
 import utilities.Visitor;
 import utilities.SymbolTable;
@@ -10,26 +11,33 @@ public class ForStmt extends Statement {
 
     public SymbolTable symbolTable;
 
-    private Vector<LocalDecl> forVars;
-    private Expression cond;
+    private LocalDecl loopControlVar;
+    private Expression LHS;
+    private Expression RHS;
+    private LoopOp lOp;
     private Statement nextExpr;
     private BlockStmt body;
 
-    public ForStmt(Token t, Vector<LocalDecl> fv, Expression c, Statement ne, BlockStmt b) {
+    public ForStmt(Token t, LocalDecl ld, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
         super(t);
-        this.forVars = fv;
-        this.cond = c;
-        this.nextExpr = ne;
+        this.loopControlVar = ld;
+        this.LHS = LHS;
+        this.RHS = RHS;
+        this.lOp = lOp;
         this.body = b;
 
-        addChild(this.cond);
-        addChild(this.nextExpr);
+        addChild(this.loopControlVar);
+        addChild(this.LHS);
+        addChild(this.RHS);
+        addChild(this.lOp);
         addChild(this.body);
         setParent();
     }
 
-    public Vector<LocalDecl> forInits() { return forVars; }
-    public Expression condition() { return cond; }
+    public LocalDecl loopVar() { return this.loopControlVar; }
+    public Expression condLHS() { return this.LHS; }
+    public Expression condRHS() { return this.RHS; }
+    public LoopOp loopOp() { return this.lOp; }
     public Statement nextExpr() { return nextExpr; }
     public BlockStmt forBlock() { return body; }
 

--- a/src/ast/statements/ForStmt.java
+++ b/src/ast/statements/ForStmt.java
@@ -11,15 +11,15 @@ public class ForStmt extends Statement {
 
     public SymbolTable symbolTable;
 
-    private LocalDecl loopControlVar;
+    private Var loopControlVar;
     private Expression LHS;
     private Expression RHS;
     private LoopOp lOp;
     private BlockStmt body;
 
-    public ForStmt(Token t, LocalDecl ld, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
+    public ForStmt(Token t, Var v, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
         super(t);
-        this.loopControlVar = ld;
+        this.loopControlVar = v;
         this.LHS = LHS;
         this.RHS = RHS;
         this.lOp = lOp;
@@ -33,7 +33,7 @@ public class ForStmt extends Statement {
         setParent();
     }
 
-    public LocalDecl loopVar() { return this.loopControlVar; }
+    public Var loopVar() { return this.loopControlVar; }
     public Expression condLHS() { return this.LHS; }
     public Expression condRHS() { return this.RHS; }
     public LoopOp loopOp() { return this.lOp; }

--- a/src/ast/statements/ForStmt.java
+++ b/src/ast/statements/ForStmt.java
@@ -15,7 +15,6 @@ public class ForStmt extends Statement {
     private Expression LHS;
     private Expression RHS;
     private LoopOp lOp;
-    private Statement nextExpr;
     private BlockStmt body;
 
     public ForStmt(Token t, LocalDecl ld, Expression LHS, Expression RHS, LoopOp lOp, BlockStmt b) {
@@ -38,7 +37,6 @@ public class ForStmt extends Statement {
     public Expression condLHS() { return this.LHS; }
     public Expression condRHS() { return this.RHS; }
     public LoopOp loopOp() { return this.lOp; }
-    public Statement nextExpr() { return nextExpr; }
     public BlockStmt forBlock() { return body; }
 
     public boolean isForStmt() { return true; }

--- a/src/interpreter/Interpreter.java
+++ b/src/interpreter/Interpreter.java
@@ -482,8 +482,10 @@ public class Interpreter extends Visitor {
 
     /*
     ___________________________ For Statements ___________________________
-    With a for loop, we will evaluate the loop variable declarations, and
-    we will execute the loop until the loop condition becomes false.
+    Since for loops are static, we will evaluate the LHS/RHS of the
+    conditional statement to determine the number of iterations we need to
+    do. From there, we will just execute the loop body and update our
+    iteration counter in the stack.
     ______________________________________________________________________
     */
     public void visitForStmt(ForStmt fs) {
@@ -506,7 +508,12 @@ public class Interpreter extends Visitor {
                 break;
         }
 
-        for(int i = LHS; i <= RHS; i++) { fs.forBlock().visit(this); }
+        stack.addValue(fs.loopVar().toString(),LHS);
+
+        for(int i = LHS; i <= RHS; i++) {
+            stack.setValue(fs.loopVar().toString(),i);
+            fs.forBlock().visit(this);
+        }
     }
 
     /*

--- a/src/interpreter/Interpreter.java
+++ b/src/interpreter/Interpreter.java
@@ -3,6 +3,7 @@ package interpreter;
 import ast.*;
 import ast.class_body.*;
 import ast.expressions.*;
+import ast.operators.LoopOp;
 import ast.statements.*;
 import ast.top_level_decls.*;
 import utilities.*;
@@ -486,12 +487,26 @@ public class Interpreter extends Visitor {
     ______________________________________________________________________
     */
     public void visitForStmt(ForStmt fs) {
-        fs.forInits().visit(this);
-        fs.condition().visit(this);
-        while((boolean)currValue) {
-            fs.forBlock().visit(this);
-            fs.condition().visit(this);
+        fs.condLHS().visit(this);
+        int LHS = (int) currValue;
+
+        fs.condRHS().visit(this);
+        int RHS = (int) currValue;
+
+        switch(fs.loopOp().toString()) {
+            case "<..":
+                LHS += 1;
+                break;
+            case "..<":
+                RHS -= 1;
+                break;
+            case "<..<":
+                LHS += 1;
+                RHS -= 1;
+                break;
         }
+
+        for(int i = LHS; i <= RHS; i++) { fs.forBlock().visit(this); }
     }
 
     /*

--- a/src/messages/MessageType.java
+++ b/src/messages/MessageType.java
@@ -74,6 +74,13 @@ public enum MessageType {
     TYPE_ERROR_432,
     TYPE_ERROR_433,
     TYPE_ERROR_434,
+    TYPE_ERROR_435,
+    TYPE_ERROR_436,
+    TYPE_ERROR_437,
+    TYPE_ERROR_438,
+    TYPE_ERROR_439,
+    TYPE_ERROR_440,
+    TYPE_ERROR_441,
 
     /*      MOD ERRORS     */
     MOD_ERROR_500,

--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -1779,7 +1779,7 @@ public class Parser {
         Token t = currentLA();
         Expression left = shiftExpression();
 
-        if(isInShiftExpressionFOLLOW()) {
+        if(isInShiftExpressionFOLLOW() && !nextLA(TokenType.INC,1)) {
             BinaryExpr mainBE = null, be = null;
             while(isInShiftExpressionFOLLOW()) {
                 BinaryOp bo = null;

--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -1391,7 +1391,7 @@ public class Parser {
 
         match(TokenType.INC);
 
-        return new LoopOp(t,LoopType.EXCL_L);
+        return new LoopOp(t,LoopType.INCL);
     }
 
     // exclusive_right : '..<' ;

--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -1348,7 +1348,7 @@ public class Parser {
         match(TokenType.LPAREN);
 
         Vector<AST> forCondition = rangeIterator();
-        LocalDecl forVar = forCondition.get(0).asStatement().asLocalDecl();
+        Var forVar = forCondition.get(0).asVar();
         Expression LHS = forCondition.get(1).asExpression();
         Expression RHS = forCondition.get(3).asExpression();
         LoopOp loopOp = forCondition.get(2).asOperator().asLoopOp();

--- a/src/parser/Parser.java
+++ b/src/parser/Parser.java
@@ -1348,7 +1348,7 @@ public class Parser {
         match(TokenType.LPAREN);
 
         Vector<AST> forCondition = rangeIterator();
-        Var forVar = forCondition.get(0).asVar();
+        LocalDecl forVar = forCondition.get(0).asStatement().asLocalDecl();
         Expression LHS = forCondition.get(1).asExpression();
         Expression RHS = forCondition.get(3).asExpression();
         LoopOp loopOp = forCondition.get(2).asOperator().asLoopOp();
@@ -1367,7 +1367,8 @@ public class Parser {
         Vector<AST> forComponents = new Vector<AST>();
 
         match(TokenType.DEF);
-        forComponents.append(variableDeclInit());
+        Var v = variableDeclInit();
+        forComponents.append(new LocalDecl(t,v,v.type()));
         match(TokenType.IN);
 
         forComponents.append(expression());

--- a/src/type_checker/TypeChecker.java
+++ b/src/type_checker/TypeChecker.java
@@ -542,8 +542,8 @@ public class TypeChecker extends Visitor {
 
                 // ERROR CHECK #5: Make sure the label's right constant is greater than the left constant
                 if(choiceType.isInt()) {
-                    int lLabel = Integer.valueOf(currCase.choiceLabel().leftLabel().getText());
-                    int rLabel = Integer.valueOf(currCase.choiceLabel().rightLabel().getText());
+                    int lLabel = Integer.valueOf(currCase.choiceLabel().leftLabel().toString());
+                    int rLabel = Integer.valueOf(currCase.choiceLabel().rightLabel().toString());
                     if(rLabel <= lLabel) {
                         errors.add(new ErrorBuilder(generateTypeError,interpretMode)
                                 .addLocation(currCase.choiceLabel())
@@ -845,9 +845,9 @@ public class TypeChecker extends Visitor {
         }
 
         // ERROR CHECK #6: Make sure the LHS is smaller than the RHS of the loop condition
-        if(Integer.parseInt(fs.condLHS().asLiteral().getText()) >= Integer.parseInt(fs.condRHS().asLiteral().getText())) {
+        if(Integer.parseInt(fs.condLHS().toString()) >= Integer.parseInt(fs.condRHS().toString())) {
             errors.add(new ErrorBuilder(generateTypeError,interpretMode)
-                    .addLocation(fs.condLHS())
+                    .addLocation(fs)
                     .addErrorType(MessageType.TYPE_ERROR_441)
                     .addArgs()
                     .error());

--- a/src/type_checker/TypeChecker.java
+++ b/src/type_checker/TypeChecker.java
@@ -784,28 +784,76 @@ public class TypeChecker extends Visitor {
 
     /*
     ___________________________ For Statements ___________________________
-    Just like with do statements, we only check if the for loop's
-    condition evaluates to be a Bool. There's nothing else FOR us to type
-    check here. ;)
+    Unlike the other two loop statements, we have a few error checks that
+    need to be done with for statements. We mainly need to make sure the
+    for loop has a loop control variable that represents an Int, and its
+    condition contains Int literals. Once done, then there's nothing else
+    FOR us to type check here. ;)
     ______________________________________________________________________
     */
     public void visitForStmt(ForStmt fs) {
         currentScope = fs.symbolTable;
 
-        fs.condition().visit(this);
+        fs.loopVar().visit(this);
+        Type varType = fs.loopVar().type();
 
-        // ERROR CHECK #1: Make sure For's condition evaluates to Bool
-        if(!fs.condition().type.isBool()) {
+        // ERROR CHECK #1: Make sure loop control variable is an Int
+        if(!varType.isInt()) {
             errors.add(new ErrorBuilder(generateTypeError,interpretMode)
-                    .addLocation(fs.condition())
+                    .addLocation(fs.loopVar())
                     .addErrorType(MessageType.TYPE_ERROR_407)
-                    .addArgs(fs.condition().type)
+                    .addArgs()
                     .error());
         }
 
-        if(fs.nextExpr() != null) { fs.nextExpr().visit(this); }
-        if(fs.forBlock() != null) { fs.forBlock().visit(this); }
+        // ERROR CHECK #2: Make sure LHS of condition is a literal
+        if(!fs.condLHS().isLiteral()) {
+            errors.add(new ErrorBuilder(generateTypeError,interpretMode)
+                    .addLocation(fs.loopVar())
+                    .addErrorType(MessageType.TYPE_ERROR_437)
+                    .addArgs()
+                    .error());
+        }
 
+        fs.condLHS().visit(this);
+        // ERROR CHECK #3: Make sure LHS of condition is an Int
+        if(!fs.condLHS().type.isInt()) {
+            errors.add(new ErrorBuilder(generateTypeError,interpretMode)
+                    .addLocation(fs.condLHS())
+                    .addErrorType(MessageType.TYPE_ERROR_438)
+                    .addArgs(fs.condLHS().type)
+                    .error());
+        }
+
+        // ERROR CHECK #4: Make sure RHS of condition is a literal
+        if(!fs.condLHS().isLiteral()) {
+            errors.add(new ErrorBuilder(generateTypeError,interpretMode)
+                    .addLocation(fs.condRHS())
+                    .addErrorType(MessageType.TYPE_ERROR_439)
+                    .addArgs()
+                    .error());
+        }
+
+        fs.condRHS().visit(this);
+        // ERROR CHECK #5: Make sure RHS of condition is an Int
+        if(!fs.condLHS().type.isInt()) {
+            errors.add(new ErrorBuilder(generateTypeError,interpretMode)
+                    .addLocation(fs.condRHS())
+                    .addErrorType(MessageType.TYPE_ERROR_440)
+                    .addArgs(fs.condRHS().type)
+                    .error());
+        }
+
+        // ERROR CHECK #6: Make sure the LHS is smaller than the RHS of the loop condition
+        if(Integer.parseInt(fs.condLHS().asLiteral().getText()) >= Integer.parseInt(fs.condRHS().asLiteral().getText())) {
+            errors.add(new ErrorBuilder(generateTypeError,interpretMode)
+                    .addLocation(fs.condLHS())
+                    .addErrorType(MessageType.TYPE_ERROR_441)
+                    .addArgs()
+                    .error());
+        }
+
+        if(fs.forBlock() != null) { fs.forBlock().visit(this); }
         currentScope = currentScope.closeScope();
     }
 

--- a/src/utilities/MessageType.properties
+++ b/src/utilities/MessageType.properties
@@ -43,8 +43,7 @@ TYPE_ERROR_404 = The binary expression has LHS type '<arg0>' and RHS type '<arg1
 TYPE_ERROR_405 = The unary expression has type '<arg0>'.
 TYPE_ERROR_406 = The if statement's condition evaluates to be '<arg0>', but the condition \
                  must evaluate to be a value of type 'Bool'.
-TYPE_ERROR_407 = The loop's condition evaluates to be '<arg0>', but the condition \
-                 must evaluate to be a value of type 'Bool'.
+TYPE_ERROR_407 = The loop control variable must be of type 'Int'.
 TYPE_ERROR_408 = An expression of type 'Int' can only be casted to types 'Char' and 'Real'.
 TYPE_ERROR_409 = An expression of type 'Char' can only be casted to types 'Int' and 'String'.
 TYPE_ERROR_410 = An expression of type 'Real' can only be casted to type 'Int'.
@@ -69,11 +68,18 @@ TYPE_ERROR_426 = Choice statement was given a value of type '<arg0>'.
 TYPE_ERROR_427 = Case statement label has type '<arg0>', but choice statement has type '<arg1>'.
 TYPE_ERROR_428 = Function '<arg0>' can not be invoked since there isn't a valid overload.
 TYPE_ERROR_429 = Method '<arg0>' can not be invoked since there isn't a valid overload.
-TYPE_ERROR_430 = '<arg0>' is not a valid List or Array, so it can not be indexed.
-TYPE_ERROR_431 = Array index expression is of type '<arg0>', but it must have type 'Int'.
-TYPE_ERROR_432 = The enumeration '<arg0>' has no valid ordering that the compiler can generate.
-TYPE_ERROR_433 = A choice statement with a String value can only have a single label constant for cases.
-TYPE_ERROR_434 = The right constant of a case label must be greater in value than the left constant of the same case label.
+TYPE_ERROR_430 = Array index expression is of type '<arg0>', but it must have type 'Int'.
+TYPE_ERROR_431 = The enumeration '<arg0>' has no valid ordering that the compiler can generate.
+TYPE_ERROR_432 = A choice statement with a String value can only have a single label constant for cases.
+TYPE_ERROR_433 = The right constant of a case label must be greater in value than the left constant of the same case label.
+TYPE_ERROR_434 = '<arg0>' does not represent a valid array type and can not be dereferenced.
+TYPE_ERROR_435 = An array literal can not be assigned to a non-array type variable.
+TYPE_ERROR_436 = An array literal can only have dimensions with type 'Int' and not type '<arg0>'.
+TYPE_ERROR_437 = The LHS of the for loop condition must be an 'Int' literal value.
+TYPE_ERROR_438 = The LHS of the for loop condition has type '<arg0>', but it should be of type 'Int'.
+TYPE_ERROR_439 = The RHS of the for loop condition must be an 'Int' literal value.
+TYPE_ERROR_440 = The RHS of the for loop condition has type '<arg0>', but it should be of type 'Int'
+TYPE_ERROR_441 = THE LHS of the for loop condition should be smaller than the RHS of the for loop condition.
 
 #  MOD ERRORS
 MOD_ERROR_500 = Class '<arg0>' can not inherit from class '<arg1>'.


### PR DESCRIPTION
# Overview
This PR introduces new syntax concerning C Minor for loops, and it will close #16.

# Description
I have changed the C Minor for loop to be based on its original design. For loops will now take the form `for(<var> in <expr>) <body>` where `<expr>` is a compound comparison (Ex. `1<..<5`). The ForStmt node has been redesigned to now have 3 new fields: a LHS Expression and a RHS expression that should represent literal integers in the compound comparison alongside an operator denoting the comparison being made (either `..`, `<..`,`..<`, and `<..<`). I have readded the initial for loop grammar rules, so the parser is able to generate the correct AST now.

Additionally, I have updated both the `NameChecker` and `TypeChecker` to account for the new changes in the ForStmt. This has also resulted in the addition of 6 new type errors related to the correct typing of the for loop conditional statement. The interpreter has also been updated to handle for statements. In the future, there will be another update to allow a second type of for loop to exist for iterable structures (such as for arrays and lists) once they are implemented in the language.